### PR TITLE
Ensure attributes are removed

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -46,6 +46,16 @@ Key features:
     foo.forge! # => Saves the model with the attributes { height: 20, width: 5, name: 'El Capitan' }
   ```
 
+Note calling `record_data_entries` builds the data_entries, but the data_entries are not created and prioritized until `forge!`
+
+3. Remove data for an existing model from any of your sources.
+  ```ruby
+    foo.remove_data_entries(source1)
+    foo.forge! # => Saves the model with the attributes { height: 19, width: nil, name: 'El Capitan' }
+  ```
+
+Note calling `remove_data_entries` marks the data_entries for destruction, but the data_entries are destroyed and nullified until `forge!`
+
 ### Overriding Priority
 
 The priority of a data entry can be customized to override the priority inherited from the data source.

--- a/Readme.md
+++ b/Readme.md
@@ -46,7 +46,7 @@ Key features:
     foo.forge! # => Saves the model with the attributes { height: 20, width: 5, name: 'El Capitan' }
   ```
 
-Note calling `record_data_entries` builds the data_entries, but the data_entries are not created and prioritized until `forge!`
+**Note:** Calling `record_data_entries` builds the Data Entries, but they are not persisted and and the record's attributes not updated until `forge!` is called.
 
 3. Remove data for an existing model from any of your sources.
   ```ruby
@@ -54,7 +54,7 @@ Note calling `record_data_entries` builds the data_entries, but the data_entries
     foo.forge! # => Saves the model with the attributes { height: 19, width: nil, name: 'El Capitan' }
   ```
 
-Note calling `remove_data_entries` marks the data_entries for destruction, but the data_entries are destroyed and nullified until `forge!`
+**Note:** calling `remove_data_entries` marks the Data Entries for destruction, but they are not destroyed and the removed attributes not nullified until `forge!` is called.
 
 ### Overriding Priority
 

--- a/lib/laforge/activerecord.rb
+++ b/lib/laforge/activerecord.rb
@@ -3,7 +3,7 @@ module LaForge
     extend ActiveSupport::Concern
 
     def laforged
-      has_many :data_entries, as: :record, dependent: :delete_all, class_name: 'LaForge::DataEntry'
+      has_many :data_entries, as: :record, dependent: :delete_all, autosave: true, class_name: 'LaForge::DataEntry'
       has_many :data_sources, through: :source_data_entries, class_name: 'LaForge::DataSource'
 
       scope :with_source, ->(source) { joins(:data_entries).merge(DataEntry.with_source(source)) }
@@ -59,11 +59,22 @@ module LaForge
     # Optionally pass `sources` to limit data entries used in the calculation to only those from the given sources
     def forge_attributes(attributes: nil, sources: nil)
       forged_attrs = {}
+
       filter_loaded_data_entries(attributes: attributes, sources: sources, present: true).sort_by(&:priority_with_fallback).reverse.uniq(&:attribute_name).each do |data_entry|
-        forged_attrs[data_entry.attribute_name] = data_entry.value
+        value = data_entry.marked_for_destruction? ? nil : data_entry.value
+        forged_attrs[data_entry.attribute_name] = value
       end
 
       return forged_attrs
+    end
+
+    # Mark several data entries for destruction
+    # Optionally pass `attributes` to limit data entries used in the calculation to only those for the given attributes
+    # Optionally pass `sources` to limit data entries used in the calculation to only those from the given sources
+    def remove_data_entries(attribute_names: nil, sources: nil)
+      filter_loaded_data_entries(attributes: attribute_names, sources: sources).each do |data_entry|
+        data_entry.mark_for_destruction
+      end
     end
 
     # Record several pieces of information from the same source.
@@ -90,13 +101,22 @@ module LaForge
 
     # Returns a list of the entries matching the filters
     def filter_loaded_data_entries(attributes: nil, sources: nil, present: nil)
-      list = data_entries
-      list = list.with_attribute(attributes) unless attributes.nil?
-      list = list.with_source(sources) unless sources.nil?
+      list = data_entries.to_a
+
+      unless attributes.nil?
+        attributes = Array.wrap(attributes).map(&:to_s)
+        list.select! {|data_entry| attributes.include?(data_entry.attribute_name) }
+      end
+
+      unless sources.nil?
+        source_ids = Array.wrap(sources).map {|source| DataSource.normalize_source_id(source) }
+        list.select! {|data_entry| source_ids.include?(data_entry.source_id) }
+      end
+
       list = list.select(&:present?) if present == true
       list = list.reject(&:present?) if present == false
 
-      return list.to_a
+      return list
     end
   end
 end

--- a/lib/laforge/activerecord.rb
+++ b/lib/laforge/activerecord.rb
@@ -86,10 +86,14 @@ module LaForge
 
     # Record a single piece of information from a source.
     # Optionally pass a custom priority for that attribute and source at the same time.
-    # Optionally pass `replace: false` to leave the existing entry for the attribute and source instead of deleting it
-    def record_data_entry(attribute_name, value, source, priority: nil, replace: true)
-      data_entries.destroy(*filter_loaded_data_entries(attributes: attribute_name, sources: source)) if replace
-      data_entries << DataEntry.new(attribute_name: attribute_name, value: value, source_id: source, priority: priority)
+    def record_data_entry(attribute_name, value, source, priority: nil)
+      exiting_data_entry = filter_loaded_data_entries(attributes: attribute_name, sources: source).first
+      if exiting_data_entry
+        exiting_data_entry.value = value
+        exiting_data_entry.priority = priority
+      else
+        data_entries.build(attribute_name: attribute_name, value: value, source_id: source, priority: priority)
+      end
     end
 
     # Set and save the priority of a source for the source of a single attribute

--- a/spec/lib/activerecord_spec.rb
+++ b/spec/lib/activerecord_spec.rb
@@ -104,10 +104,15 @@ describe 'ActiveRecordExtensions' do
     let(:data_source) { LaForge::DataSource.find_or_create_by(name: "bbc", priority: 1) }
     let(:record) { ActiveRecordMock.create(name: "Post") }
 
-    it 'creates a data_entry for an attribute passed' do
+    it 'builds a data_entry for an attribute passed' do
       expect { record.record_data_entries({name: "Article"}, data_source.name) }
-        .to change { record.data_entries.count }
+        .to change { record.data_entries.size }
         .by(1)
+    end
+
+    it 'does not create a new data_entry until save is called' do
+      expect { record.record_data_entries({name: "Article"}, data_source.name) }
+        .not_to change { record.data_entries.count }
     end
 
     it 'sets the source_id when a source_name is passed in' do
@@ -170,17 +175,11 @@ describe 'ActiveRecordExtensions' do
         .to(false)
     end
 
-    it 'destroys data_entries from the same source' do
+    it 'updates a data_entry for the same attribute from the same source' do
+
       record.record_data_entries({name: "Article"}, data_source.name)
       expect { record.record_data_entries({name: "Article 2"}, data_source.name) }
-        .not_to change { record.data_entries.count }
-    end
-
-    it 'does not destroy data_entries from the same source when the replace is false' do
-      record.record_data_entries({name: "Article"}, data_source.name)
-      expect { record.record_data_entries({name: "Article 2"}, data_source.name, replace: false) }
-        .to change { record.data_entries.count }
-        .from(1).to(2)
+      .not_to change { record.data_entries.pluck(:id) }
     end
   end
 
@@ -191,17 +190,20 @@ describe 'ActiveRecordExtensions' do
 
     it 'sets the record attributes from the data entries' do
       record.record_data_entries({name: "Article"}, data_source.name)
+
       expect { record.forge }.to change { record.name }.from("Post").to("Article")
     end
 
     it 'does not change the database record' do
       record.record_data_entries({name: "Article"}, data_source.name)
+
       expect { record.forge }.not_to change { record.reload.name }
     end
 
     it 'merges data_entries from multiple sources' do
       record.record_data_entries({name: "Article"}, data_source.name)
       record.record_data_entries({active: false}, prioritized_data_source.name)
+      record.save!
 
       expect { record.forge }.to change { record.changes }.to eq({"name"=>["Post", "Article"], "active"=>[true, false]})
     end
@@ -209,15 +211,17 @@ describe 'ActiveRecordExtensions' do
     it 'prioritizes based on the data_entry priority' do
       record.record_data_entries({name: "#{prioritized_data_source} Article"}, prioritized_data_source.name, priority: 3)
       record.record_data_entries({name: "#{data_source.name} Article"}, data_source.name, priority: 5)
+      record.save!
 
       expect { record.forge }.to change { record.name }.from("Post").to("#{data_source.name} Article")
     end
 
     it 'prioritizes based on the data_source priority when priority is not set on the data_entry' do
-      record.record_data_entries({name: "#{prioritized_data_source} Article"}, prioritized_data_source.name)
+      record.record_data_entries({name: "#{prioritized_data_source.name} Article"}, prioritized_data_source.name)
       record.record_data_entries({name: "#{data_source.name} Article"}, data_source.name)
+      record.save!
 
-      expect { record.forge }.to change { record.name }.from("Post").to("#{prioritized_data_source} Article")
+      expect { record.forge }.to change { record.name }.from("Post").to("#{prioritized_data_source.name} Article")
     end
 
   end
@@ -228,7 +232,8 @@ describe 'ActiveRecordExtensions' do
 
     it 'changes the database record' do
       record.record_data_entries({name: "Article"}, data_source.name)
-      expect { record.forge! }.to change { record.reload.name }.from("Post").to("Article")
+
+      expect { record.forge! }.to change { record.name }.from("Post").to("Article")
     end
 
     it 'changes the database record when a block is passed that creates data entries' do
@@ -237,6 +242,8 @@ describe 'ActiveRecordExtensions' do
 
     it 'nils out the attribute when a block is passed that destroys the only data entry with that attribute' do
       record.record_data_entries({name: "Post"}, data_source.name)
+      record.save!
+
       expect { record.forge! { record.remove_data_entries(sources: data_source.name) }}.to change { record.reload.name }.from("Post").to(nil)
     end
 


### PR DESCRIPTION
When an attribute is removed from one source, and does not exist on another source, we need to make sure it gets unset