### PR TITLE
Fix changed columns

### DIFF
--- a/lib/laforge/activerecord.rb
+++ b/lib/laforge/activerecord.rb
@@ -61,6 +61,8 @@ module LaForge
       forged_attrs = {}
 
       filter_loaded_data_entries(attributes: attributes, sources: sources, present: true).sort_by(&:priority_with_fallback).reverse.uniq(&:attribute_name).each do |data_entry|
+        next unless respond_to?("#{data_entry.attribute_name}=")
+
         value = data_entry.marked_for_destruction? ? nil : data_entry.value
         forged_attrs[data_entry.attribute_name] = value
       end

--- a/lib/laforge/activerecord.rb
+++ b/lib/laforge/activerecord.rb
@@ -89,6 +89,8 @@ module LaForge
     # Record a single piece of information from a source.
     # Optionally pass a custom priority for that attribute and source at the same time.
     def record_data_entry(attribute_name, value, source, priority: nil)
+      raise InvalidAttributeName, "Cannot set #{attribute_name} on #{self.class.name}" unless respond_to?("#{attribute_name}=")
+
       exiting_data_entry = filter_loaded_data_entries(attributes: attribute_name, sources: source).first
       if exiting_data_entry
         exiting_data_entry.value = value
@@ -125,4 +127,6 @@ module LaForge
       return list
     end
   end
+
+  class InvalidAttributeName < StandardError; end
 end

--- a/spec/lib/activerecord_spec.rb
+++ b/spec/lib/activerecord_spec.rb
@@ -169,7 +169,21 @@ describe 'ActiveRecordExtensions' do
 
       expect { record.forge }.to change { record.name }.from("Post").to("#{prioritized_data_source.name} Article")
     end
+  end
 
+  describe '#forge_attributes' do
+    let(:data_source) { LaForge::DataSource.find_or_create_by(name: "bbc", priority: 1) }
+    let(:record) { ActiveRecordMock.create(name: "Post", active: true) }
+    let!(:data_entry) { LaForge::DataEntry.create!(record: record, attribute_name: "name", value: "Article", source_id: data_source.id) }
+
+    it 'returns a hash of the attributes generated the data entries' do
+      expect(record.forge_attributes).to eq({"name"=> 'Article'})
+    end
+
+    it 'removes data_entries for invalid columns' do
+      data_entry.update_column(:attribute_name, "name_invalid")
+      expect(record.forge_attributes).to eq({})
+    end
   end
 
   describe '#record_data_entries' do

--- a/spec/lib/activerecord_spec.rb
+++ b/spec/lib/activerecord_spec.rb
@@ -5,7 +5,7 @@ describe 'ActiveRecordExtensions' do
     let(:record) { ActiveRecordMock.create(name: "Post") }
     let(:record2) { ActiveRecordMock.create(name: "News") }
     let(:data_source) { LaForge::DataSource.find_or_create_by(name: "bbc", priority: 1) }
-    let(:data_source2) { LaForge::DataSource.find_or_create_by(name: "gaurdian", priority: 2) }
+    let(:data_source2) { LaForge::DataSource.find_or_create_by(name: "guardian", priority: 2) }
 
     before(:each) do
       LaForge::DataEntry.destroy_all
@@ -134,7 +134,7 @@ describe 'ActiveRecordExtensions' do
     let(:data_source) { LaForge::DataSource.find_or_create_by(name: "bbc", priority: 1) }
     let(:data_entry) { LaForge::DataEntry.new(record: record, source_id: data_source.id) }
 
-    let(:prioritized_data_source) { LaForge::DataSource.find_or_create_by(name: "gaurdian", priority: 2) }
+    let(:prioritized_data_source) { LaForge::DataSource.find_or_create_by(name: "guardian", priority: 2) }
     let(:prioritized_data_entry) { LaForge::DataEntry.new(record: record, source_id: prioritized_data_source.id) }
 
     it 'sets the record attributes from the data entries' do
@@ -147,7 +147,7 @@ describe 'ActiveRecordExtensions' do
       expect { record.forge }.not_to change { record.reload.name }
     end
 
-    it 'ignores data_entries with an invalid attribute name' do
+    it 'ignores data_entries when the attribute_name does not have a setter' do
       data_entry.update_attributes(attribute_name: "name_invalid")
       expect { record.forge }.not_to change { record.changes }
     end
@@ -167,7 +167,7 @@ describe 'ActiveRecordExtensions' do
     end
 
     it 'prioritizes based on the data_source priority when priority is not set on the data_entry' do
-      data_entry.update_attributes(attribute_name: "name", value: "Lower Prioirty")
+      data_entry.update_attributes(attribute_name: "name", value: "Lower Priority")
       prioritized_data_entry.update_attributes(attribute_name: "name", value: "Higher Priority")
 
       expect { record.forge }.to change { record.name }.from("Post").to("Higher Priority")
@@ -183,7 +183,7 @@ describe 'ActiveRecordExtensions' do
       expect(record.forge_attributes).to eq({"name"=> 'Article'})
     end
 
-    it 'removes data_entries for invalid columns' do
+    it 'excludes data_entries when the attribute_name does not have a setter' do
       data_entry.update_column(:attribute_name, "name_invalid")
       expect(record.forge_attributes).to eq({})
     end
@@ -202,6 +202,10 @@ describe 'ActiveRecordExtensions' do
     it 'does not create a new data_entry until save is called' do
       expect { record.record_data_entries({name: "Article"}, data_source.name) }
         .not_to change { record.data_entries.count }
+    end
+
+    it 'raises an error when the record does not have a setter method for the attribute_name' do
+      expect { record.record_data_entries({name2: "Article"}, data_source.name) }.to raise_exception(LaForge::InvalidAttributeName)
     end
 
     it 'sets the source_id when a source_name is passed in' do

--- a/spec/lib/activerecord_spec.rb
+++ b/spec/lib/activerecord_spec.rb
@@ -100,6 +100,78 @@ describe 'ActiveRecordExtensions' do
     end
   end
 
+  describe '#forge!' do
+    let(:data_source) { LaForge::DataSource.find_or_create_by(name: "bbc", priority: 1) }
+    let(:record) { ActiveRecordMock.create(name: "Post", active: true) }
+
+    it 'changes the database record' do
+      record.record_data_entries({name: "Article"}, data_source.name)
+
+      expect { record.forge! }.to change { record.name }.from("Post").to("Article")
+    end
+
+    it 'changes the database record when a block is passed that creates data entries' do
+      expect { record.forge! { record.record_data_entries({name: "Article"}, data_source.name) }}.to change { record.reload.name }.from("Post").to("Article")
+    end
+
+    it 'nils out the attribute when a block is passed that destroys the only data entry with that attribute' do
+      record.record_data_entries({name: "Post"}, data_source.name)
+      record.save!
+
+      expect { record.forge! { record.remove_data_entries(sources: data_source.name) }}.to change { record.reload.name }.from("Post").to(nil)
+    end
+
+    it 'does not change the attribute when the only data_entry with that attribute is destroyed outside of the block' do
+      record.record_data_entries({name: "Post"}, data_source.name)
+      record.remove_data_entries(sources: data_source.name)
+
+      expect { record.forge! }.not_to change { record.reload.name }
+    end
+  end
+
+  describe '#forge' do
+    let(:data_source) { LaForge::DataSource.find_or_create_by(name: "bbc", priority: 1) }
+    let(:prioritized_data_source) { LaForge::DataSource.find_or_create_by(name: "gaurdian", priority: 2) }
+    let(:record) { ActiveRecordMock.create(name: "Post", active: true) }
+
+    it 'sets the record attributes from the data entries' do
+      record.record_data_entries({name: "Article"}, data_source.name)
+
+      expect { record.forge }.to change { record.name }.from("Post").to("Article")
+    end
+
+    it 'does not change the database record' do
+      record.record_data_entries({name: "Article"}, data_source.name)
+
+      expect { record.forge }.not_to change { record.reload.name }
+    end
+
+    it 'merges data_entries from multiple sources' do
+      record.record_data_entries({name: "Article"}, data_source.name)
+      record.record_data_entries({active: false}, prioritized_data_source.name)
+      record.save!
+
+      expect { record.forge }.to change { record.changes }.to eq({"name"=>["Post", "Article"], "active"=>[true, false]})
+    end
+
+    it 'prioritizes based on the data_entry priority' do
+      record.record_data_entries({name: "#{prioritized_data_source} Article"}, prioritized_data_source.name, priority: 3)
+      record.record_data_entries({name: "#{data_source.name} Article"}, data_source.name, priority: 5)
+      record.save!
+
+      expect { record.forge }.to change { record.name }.from("Post").to("#{data_source.name} Article")
+    end
+
+    it 'prioritizes based on the data_source priority when priority is not set on the data_entry' do
+      record.record_data_entries({name: "#{prioritized_data_source.name} Article"}, prioritized_data_source.name)
+      record.record_data_entries({name: "#{data_source.name} Article"}, data_source.name)
+      record.save!
+
+      expect { record.forge }.to change { record.name }.from("Post").to("#{prioritized_data_source.name} Article")
+    end
+
+  end
+
   describe '#record_data_entries' do
     let(:data_source) { LaForge::DataSource.find_or_create_by(name: "bbc", priority: 1) }
     let(:record) { ActiveRecordMock.create(name: "Post") }
@@ -180,78 +252,6 @@ describe 'ActiveRecordExtensions' do
       record.record_data_entries({name: "Article"}, data_source.name)
       expect { record.record_data_entries({name: "Article 2"}, data_source.name) }
       .not_to change { record.data_entries.pluck(:id) }
-    end
-  end
-
-  describe '#forge' do
-    let(:data_source) { LaForge::DataSource.find_or_create_by(name: "bbc", priority: 1) }
-    let(:prioritized_data_source) { LaForge::DataSource.find_or_create_by(name: "gaurdian", priority: 2) }
-    let(:record) { ActiveRecordMock.create(name: "Post", active: true) }
-
-    it 'sets the record attributes from the data entries' do
-      record.record_data_entries({name: "Article"}, data_source.name)
-
-      expect { record.forge }.to change { record.name }.from("Post").to("Article")
-    end
-
-    it 'does not change the database record' do
-      record.record_data_entries({name: "Article"}, data_source.name)
-
-      expect { record.forge }.not_to change { record.reload.name }
-    end
-
-    it 'merges data_entries from multiple sources' do
-      record.record_data_entries({name: "Article"}, data_source.name)
-      record.record_data_entries({active: false}, prioritized_data_source.name)
-      record.save!
-
-      expect { record.forge }.to change { record.changes }.to eq({"name"=>["Post", "Article"], "active"=>[true, false]})
-    end
-
-    it 'prioritizes based on the data_entry priority' do
-      record.record_data_entries({name: "#{prioritized_data_source} Article"}, prioritized_data_source.name, priority: 3)
-      record.record_data_entries({name: "#{data_source.name} Article"}, data_source.name, priority: 5)
-      record.save!
-
-      expect { record.forge }.to change { record.name }.from("Post").to("#{data_source.name} Article")
-    end
-
-    it 'prioritizes based on the data_source priority when priority is not set on the data_entry' do
-      record.record_data_entries({name: "#{prioritized_data_source.name} Article"}, prioritized_data_source.name)
-      record.record_data_entries({name: "#{data_source.name} Article"}, data_source.name)
-      record.save!
-
-      expect { record.forge }.to change { record.name }.from("Post").to("#{prioritized_data_source.name} Article")
-    end
-
-  end
-
-  describe '#forge!' do
-    let(:data_source) { LaForge::DataSource.find_or_create_by(name: "bbc", priority: 1) }
-    let(:record) { ActiveRecordMock.create(name: "Post", active: true) }
-
-    it 'changes the database record' do
-      record.record_data_entries({name: "Article"}, data_source.name)
-
-      expect { record.forge! }.to change { record.name }.from("Post").to("Article")
-    end
-
-    it 'changes the database record when a block is passed that creates data entries' do
-      expect { record.forge! { record.record_data_entries({name: "Article"}, data_source.name) }}.to change { record.reload.name }.from("Post").to("Article")
-    end
-
-    it 'nils out the attribute when a block is passed that destroys the only data entry with that attribute' do
-      record.record_data_entries({name: "Post"}, data_source.name)
-      record.save!
-
-      expect { record.forge! { record.remove_data_entries(sources: data_source.name) }}.to change { record.reload.name }.from("Post").to(nil)
-    end
-
-    it 'does not change the attribute when the only data_entry with that attribute is destroyed outside of the block' do
-      record.record_data_entries({name: "Post"}, data_source.name)
-      record.remove_data_entries(sources: data_source.name)
-
-      expect { record.forge! }.not_to change { record.reload.name }
     end
   end
 end


### PR DESCRIPTION
- Remove invalid attributes when generating the attributes list. This will prevent an explosion if a column name is removed or renamed
- Raise a more helpful error when trying to create a data_entry for an attribute without a getter. 
- Reorganize specs to mimic how the DSL is used. 
- Add specs for behaviour updates.